### PR TITLE
Deleted '--maxfail=5' option from pytest.ini. In continuous integrati…

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -8,7 +8,7 @@ addopts =
     --disable-warnings
     --color=yes
     --durations=10
-    --maxfail=5
+    --maxfail=0
 
 # Markery dla testów
 markers =


### PR DESCRIPTION
Deleted '--maxfail=5' option from pytest.ini. In continuous integration and production environments, all test failures should be visible in one run to allow full error analysis and avoid missing regressions.